### PR TITLE
リツイートと引用リツイートのときには反応しないようにルールを変更、あわせて表示ポイントを週の通算ポイントに修正

### DIFF
--- a/twitter_gj_carely.py
+++ b/twitter_gj_carely.py
@@ -185,7 +185,7 @@ def get_points(name):
         # 今週の通算ポイントを取得
         week_start_day = datetime.date.today() - timedelta(days=datetime.date.today().weekday())
         cur.execute(f"SELECT SUM(rc.appreciation_count) FROM receiver_counts rc WHERE rc.user_id={user_id} AND rc.appreciation_date >= date'{week_start_day}'")
-        (appreciation_count, _) = cur.fetchone()
+        appreciation_count = cur.fetchone()[0]
 
         conn.commit()
         cur.close()


### PR DESCRIPTION
# 対応issue
[#3【不具合】リツイート、引用リツイートされるとBotが反応してしまう](https://github.com/icare-jp/twitter_gj_carely/issues/3)
[#4【不具合】週の通算ポイントではなく当日のポイントになっている](https://github.com/icare-jp/twitter_gj_carely/issues/4)

# したこと

- リツイートと引用リツイートのときには反応しないようにルールを変更しました
- Twitter GJ Carelyのリプライの中で表示しているポイントをその日のポイントから週の合計ポイントに修正しました

# 動作確認
- リツイートしても最初のリプライ以降にBotからのリプライが返ってこないこと

![スクリーンショット 2022-07-18 20 08 53](https://user-images.githubusercontent.com/72296262/179499297-facfeb8a-f174-4cce-9707-ef3fa37deeec.png)

- リプライで表示されるポイントが週の合計ポイントになっていること

<img width="896" alt="GJされた数週でカウントできてる" src="https://user-images.githubusercontent.com/72296262/179737568-8eb156ad-396e-4dac-8bfe-be035faa59c2.png">

![スクリーンショット 2022-07-19 20 11 57](https://user-images.githubusercontent.com/72296262/179737614-624c17d3-a9e6-46bc-82d4-dc0079d5f8f2.png)

