### PR TITLE
リプライの中で@を使って人を指定すると二重でポイントを加算してしまう不具合を修正

### DIFF
--- a/twitter_gj_carely.py
+++ b/twitter_gj_carely.py
@@ -193,6 +193,7 @@ def reply(response_line):
     tweet_id = int(json_response["data"]["id"])
     received_text = json_response["data"]["text"]
     names = [name for name in received_text.split() if name.startswith('@') and name != f'@{Bot_twitter_id}']
+    names = list(dict.fromkeys(names))
     combined_names = 'と'.join(names)
     reply_text = f'😎ヘイ、みんな！{combined_names} がほめられたよ！🤟' # Botが返信するテキスト
 


### PR DESCRIPTION
# 対応issue
[#5【不具合】返信のツイートに@で人を指定すると二重でポイントを加算してしまう](https://github.com/icare-jp/twitter_gj_carely/issues/5)


# したこと

- ポイントを加算してリプライを返す対象のユーザを格納しているリストに対して、重複を削除する処理を加えました

# 発生していた不具合

![スクリーンショット 2022-08-03 23 51 02](https://user-images.githubusercontent.com/72296262/182641972-d4ddf61f-cebd-4b3b-a609-9472f0132774.png)


# 動作確認

- 修正後のコードで重複を取り除けていることを確認

![スクリーンショット 2022-08-03 23 53 54](https://user-images.githubusercontent.com/72296262/182642025-6461adbb-561a-4da9-886d-df94cb928c7f.png)

![スクリーンショット 2022-08-03 23 54 08](https://user-images.githubusercontent.com/72296262/182642049-a2910d93-37bf-4bde-9892-815cc3666d84.png)

